### PR TITLE
fix error in comment about trinamic 5160 drivers on skr e3 turbo

### DIFF
--- a/src/my_machine.h
+++ b/src/my_machine.h
@@ -57,8 +57,8 @@
 //#define LASER_COOLANT_ENABLE     1 // Laser coolant plugin. To be completed.
 //#define LB_CLUSTERS_ENABLE       1 // LaserBurn cluster support.
 //#define TRINAMIC_ENABLE       2130 // Uncomment to enable Trinamic TMC2130 driver support. NOTE: Experimental for now, currently for SKR 1.x boards only
-//#define TRINAMIC_ENABLE       2209 // Uncomment to enable Trinamic TMC2209 driver support. NOTE: Experimental for now, currently for SKR 1.x boards only
-//#define TRINAMIC_ENABLE       5160 // Uncomment to enable Trinamic TMC5160 driver support. NOTE: Experimental for now, currently for SKR E3 Turbo board only
+//#define TRINAMIC_ENABLE       2209 // Uncomment to enable Trinamic TMC2209 driver support. NOTE: Experimental for now, SKR E3 Turbo and SKR 1.x boards only
+//#define TRINAMIC_ENABLE       5160 // Uncomment to enable Trinamic TMC5160 driver support. NOTE: Experimental for now, currently for SKR 1.x boards only
 //#define LIMIT_MAX_ENABLE         1 // Uncomment to enable max limit input pins (when available)
 //#define EEPROM_ENABLE           16 // I2C EEPROM/FRAM support. Set to 16 for 2K, 32 for 4K, 64 for 8K, 128 for 16K and 256 for 16K capacity.
 //#define EEPROM_IS_FRAM          1 // Uncomment when EEPROM is enabled and chip is FRAM, this to remove write delay.


### PR DESCRIPTION
Not sure if this was intended to hack together support for the SKR E3 Turbo, but the SKR E3 Turbo is driven by trinamic 2209s, and are not capable of having 5160, updated comment to reflect that.